### PR TITLE
properties instead of functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Usage Example
     sensor.conversion_time = ConversionTime.TIME_100MS
     sensor.mode = Mode.CONTINUOUS
     while True:
-        x, y, lux = sensor.get_cie()
+        x, y, lux = sensor.cie
         print(f"CIE x:{x}, y:{y}, lux: {lux}", end=" ")
         print(f"K: {sensor.calculate_color_temperature(x,y)}")
         time.sleep(1)

--- a/examples/opt4048_fulltest.py
+++ b/examples/opt4048_fulltest.py
@@ -120,7 +120,7 @@ print(
 while True:
     try:
         # Read all four channels from the sensor (raw ADC values)
-        x, y, z, w = sensor.get_channels_raw()
+        x, y, z, w = sensor.all_channels
 
         print("Channel readings (raw values):")
         print(f"X (CH0): {x}")
@@ -129,7 +129,7 @@ while True:
         print(f"W (CH3): {w}")
 
         # Calculate and display CIE chromaticity coordinates and lux
-        CIEx, CIEy, lux = sensor.get_cie()
+        CIEx, CIEy, lux = sensor.cie
         print("\nCIE Coordinates:")
         print(f"CIE x: {CIEx}")
         print(f"CIE y: {CIEy}")

--- a/examples/opt4048_interruptpin.py
+++ b/examples/opt4048_interruptpin.py
@@ -36,7 +36,7 @@ while True:
     try:
         if pin_counter.count > 0:
             pin_counter.reset()
-            x, y, lux = sensor.get_cie()
+            x, y, lux = sensor.cie
             print(f"CIE x:{x}, y:{y}, lux: {lux}", end=" ")
             print(f"K: {sensor.calculate_color_temperature(x, y)}", end=" ")
             print(f"Read Delay: {time.monotonic() - last_read_time} sec")

--- a/examples/opt4048_oneshot.py
+++ b/examples/opt4048_oneshot.py
@@ -33,7 +33,7 @@ while True:
     if sensor.mode == Mode.POWERDOWN:
         # ok we finished the reading!
         try:
-            CIEx, CIEy, lux = sensor.get_cie()
+            CIEx, CIEy, lux = sensor.cie
         except RuntimeError:
             print("Error reading sensor data")
 

--- a/examples/opt4048_simpletest.py
+++ b/examples/opt4048_simpletest.py
@@ -22,7 +22,7 @@ sensor.range = Range.AUTO
 sensor.conversion_time = ConversionTime.TIME_100MS
 sensor.mode = Mode.CONTINUOUS
 while True:
-    x, y, lux = sensor.get_cie()
+    x, y, lux = sensor.cie
     print(f"CIE x:{x}, y:{y}, lux: {lux}", end=" ")
     print(f"K: {sensor.calculate_color_temperature(x,y)}")
     time.sleep(1)

--- a/examples/opt4048_webserial.py
+++ b/examples/opt4048_webserial.py
@@ -32,7 +32,7 @@ last_read_time = 0
 while True:
     if time.monotonic() > last_read_time + READ_INTERVAL:
         last_read_time = time.monotonic()
-        x, y, lux = sensor.get_cie()
+        x, y, lux = sensor.cie
         print("---CIE Data---")
         print(f"CIE x: {x}")
         print(f"CIE y: {y}")


### PR DESCRIPTION
Changing `.get_channels_raw()` to `.all_channels` and `.get_cie()` to `.cie` to follow https://docs.circuitpython.org/en/9.2.x/docs/design_guide.html#getters-setters. Also `all_channels` property has precedent on other light / color sensors.

All examples and readme are udpated.

Technically this is a breaking change, but the library hasn't been merged to the bundle yet, and likely is not in use by anyone so I am not going to bump the major semver number.