### PR TITLE
catch the CRC check error and just retry

### DIFF
--- a/examples/opt4048_oneshot.py
+++ b/examples/opt4048_oneshot.py
@@ -34,16 +34,16 @@ while True:
         # ok we finished the reading!
         try:
             CIEx, CIEy, lux = sensor.cie
+
+            print("\nCIE Coordinates:")
+            print(f"CIE x:{CIEx}, y:{CIEy}, lux: {lux}", end=" ")
+
+            # Calculate and display color temperature
+            color_temp = sensor.calculate_color_temperature(CIEx, CIEy)
+            print(f"Color Temperature: {color_temp} K")
+            print(f"Time since last read: {time.monotonic() - timestamp} sec")
+            timestamp = time.monotonic()
         except RuntimeError:
             print("Error reading sensor data")
-
-        print("\nCIE Coordinates:")
-        print(f"CIE x:{CIEx}, y:{CIEy}, lux: {lux}", end=" ")
-
-        # Calculate and display color temperature
-        color_temp = sensor.calculate_color_temperature(CIEx, CIEy)
-        print(f"Color Temperature: {color_temp} K")
-        print(f"Time since last read: {time.monotonic() - timestamp} sec")
-        timestamp = time.monotonic()
 
         sensor.mode = Mode.AUTO_ONESHOT

--- a/examples/opt4048_simpletest.py
+++ b/examples/opt4048_simpletest.py
@@ -22,7 +22,11 @@ sensor.range = Range.AUTO
 sensor.conversion_time = ConversionTime.TIME_100MS
 sensor.mode = Mode.CONTINUOUS
 while True:
-    x, y, lux = sensor.cie
-    print(f"CIE x:{x}, y:{y}, lux: {lux}", end=" ")
-    print(f"K: {sensor.calculate_color_temperature(x,y)}")
-    time.sleep(1)
+    try:
+        x, y, lux = sensor.cie
+        print(f"CIE x:{x}, y:{y}, lux: {lux}", end=" ")
+        print(f"K: {sensor.calculate_color_temperature(x,y)}")
+        time.sleep(1)
+    except RuntimeError:
+        # CRC check failed while reading data
+        pass

--- a/examples/opt4048_webserial.py
+++ b/examples/opt4048_webserial.py
@@ -31,11 +31,15 @@ sensor.mode = Mode.CONTINUOUS
 last_read_time = 0
 while True:
     if time.monotonic() > last_read_time + READ_INTERVAL:
-        last_read_time = time.monotonic()
-        x, y, lux = sensor.cie
-        print("---CIE Data---")
-        print(f"CIE x: {x}")
-        print(f"CIE y: {y}")
-        print(f"Lux: {lux}")
-        print(f"Color Temperature: {sensor.calculate_color_temperature(x,y)} K")
-        print("-------------")
+        try:
+            last_read_time = time.monotonic()
+            x, y, lux = sensor.cie
+            print("---CIE Data---")
+            print(f"CIE x: {x}")
+            print(f"CIE y: {y}")
+            print(f"Lux: {lux}")
+            print(f"Color Temperature: {sensor.calculate_color_temperature(x,y)} K")
+            print("-------------")
+        except RuntimeError:
+            # CRC check failed while reading data
+            pass


### PR DESCRIPTION
occasionally reading data from the sensor fails due to the CRC check failing. Some of the examples already caught this exception and retried next iteration. 

This changes the remaining examples to also catch that error and ignore it / retry next iteration. 